### PR TITLE
Image Upload Endpoint

### DIFF
--- a/internal/service/imageupload/imageupload.go
+++ b/internal/service/imageupload/imageupload.go
@@ -1,0 +1,55 @@
+// Copyright 2023 SaferPlace
+
+// Package imageupload allows for HTTP image uploads to a cloud storage.
+package imageupload
+
+import (
+	"fmt"
+	"net/http"
+
+	"go.uber.org/zap"
+	"safer.place/realtime/internal/storage"
+)
+
+// Service is the image upload service
+type Service struct {
+	storage storage.Storage
+	log     *zap.Logger
+}
+
+// Register registers the image upload service.
+func Register(log *zap.Logger, store storage.Storage) func() (string, http.Handler) {
+	return func() (string, http.Handler) {
+		return "/v1/upload", &Service{
+			log:     log,
+			storage: store,
+		}
+	}
+}
+
+// ServeHTTP is the handler accepting the image upload.
+func (s *Service) ServeHTTP(w http.ResponseWriter, r *http.Request) {
+	if err := r.ParseForm(); err != nil {
+		s.log.Error("unable to parse form data", zap.Error(err))
+		http.Error(w, "unable to parse form", http.StatusBadRequest)
+		return
+	}
+	file, header, err := r.FormFile("image")
+	if err != nil {
+		s.log.Error("unable to get image from user", zap.Error(err))
+		http.Error(w, "image upload failed", http.StatusBadRequest)
+		return
+	}
+	defer file.Close()
+
+	reference, err := s.storage.Upload(
+		r.Context(), file, header.Size, header.Header.Get("Content-Type"))
+	if err != nil {
+		s.log.Error("image upload failed", zap.Error(err))
+		http.Error(w, "image upload failed", http.StatusInternalServerError)
+		return
+	}
+
+	w.WriteHeader(http.StatusOK)
+	fmt.Fprint(w, reference)
+}

--- a/internal/storage/storage.go
+++ b/internal/storage/storage.go
@@ -1,0 +1,16 @@
+// Copyright 2023 SaferPlace
+
+package storage
+
+import (
+	"context"
+	"io"
+)
+
+// Storage allows to upload the image
+type Storage interface {
+	// Upload takes in the reader from which it reads from to get the image and returns the
+	// reference which can uniquely identify the image, or an error if there was a problem uploading
+	// to the bucket.
+	Upload(ctx context.Context, r io.Reader, size int64, contentType string) (string, error)
+}


### PR DESCRIPTION
Add the image upload endpoint service. For now this has a v1 prefix but
that might be changed or dropped.

Closes #38
