### PR TITLE
Rename CI to Go (CI)

### DIFF
--- a/.github/workflows/go-ci.yml
+++ b/.github/workflows/go-ci.yml
@@ -1,14 +1,23 @@
 # Workflow used as Continous Integration every time we have a PR.
-name: CI
+name: Go
 
 on:
   # Only build when pushed to main
   push:
     branches:
-    - main
+      - main
+    paths:
+      - '**.go'
+      - 'go.mod'
+      - 'go.sum'
   # Build all pull requests
   pull_request:
-
+    branches:
+      - main
+    paths:
+      - '**.go'
+      - 'go.mod'
+      - 'go.sum'
 jobs:
   lint:
     name: Lint


### PR DESCRIPTION
The CI will only trigger for changes in Go code, therefore the CI is
renamed to Go CI.

Closes #48
