### PR TITLE
Add Write permission for the Github Token

### DIFF
--- a/.github/workflows/ts-ci.yml
+++ b/.github/workflows/ts-ci.yml
@@ -16,6 +16,12 @@ on:
     paths:
     - 'packages/**'
     - 'package.json'
+
+permissions:
+  actions: write
+  checks: write
+  deployments: write
+
 jobs:
   lint:
     name: Lint


### PR DESCRIPTION
This should be useful for dependabot failed alerts.
