### PR TITLE
pwa: Take Photo

### DIFF
--- a/packages/pwa/src/components/photocapture.tsx
+++ b/packages/pwa/src/components/photocapture.tsx
@@ -1,0 +1,53 @@
+import { CameraAltOutlined } from "@mui/icons-material";
+import { Box, Button, Stack, styled } from "@mui/material"
+import { useTranslation } from "react-i18next";
+
+export type Props = {
+    image?: File
+    setImage: (file: File) => void
+}
+
+const VisuallyHiddenInput = styled('input')`
+    clip: rect(0 0 0 0);
+    clip-path: inset(50%);
+    height: 1px;
+    overflow: hidden;
+    position: absolute;
+    bottom: 0;
+    left: 0;
+    white-space: nowrap;
+    width: 1px;
+`;
+
+export default function PhotoCapture({image, setImage}: Props) {
+    const { t } = useTranslation()
+
+    return (
+        <Stack spacing={2}>
+            { image && (
+                <Box sx={{ display: 'flex', width: '100%', direction: 'column'}}>
+                    <img src={URL.createObjectURL(image)} width='100%' />
+                </Box>
+            )}
+            <Button
+                component='label'
+                variant='outlined'
+                fullWidth
+                startIcon={<CameraAltOutlined />}
+            >
+                {t(image ? 'action:retakePhoto' : 'action:takePhoto')}
+                <VisuallyHiddenInput
+                    type='file'
+                    accept='image/*'
+                    capture
+                    onChange={(e) => {
+                        if (!e.target.files || e.target.files.length === 0) {
+                            return
+                        }
+                        setImage(e.target.files[0])
+                    }}
+                />
+            </Button>
+        </Stack>
+    )
+}

--- a/packages/pwa/src/hooks/client.ts
+++ b/packages/pwa/src/hooks/client.ts
@@ -7,12 +7,16 @@ export default function useClient<T extends ServiceType>(service: T): PromiseCli
     return React.useMemo(() => getClient(service), [service])
 }
 
+export function getEndpoint(): string {
+    return localStorage.getItem('backend') ?? import.meta.env.VITE_BACKEND
+}
+
 /**
  * getClient creates a new client
  * @param service that the client should connect to.
  */
 export function getClient<T extends ServiceType>(service: T): PromiseClient<T> {
-    const backend = localStorage.getItem('backend') ?? import.meta.env.VITE_BACKEND
+    const backend = getEndpoint()
     const transport = createConnectTransport({
         baseUrl: backend
     })

--- a/packages/pwa/src/locale/en.ts
+++ b/packages/pwa/src/locale/en.ts
@@ -14,6 +14,8 @@ export default {
         viewIncidents: "View Incidents",
         viewIncident: "View Incident",
         submitReport: "Submit Report",
+        takePhoto: "Take Photo",
+        retakePhoto: "Retake Photo",
     },
     phrases: {
         addToHomeScreen: "Add SaferPlace to your homescreen for easier access!",

--- a/packages/pwa/src/locale/index.ts
+++ b/packages/pwa/src/locale/index.ts
@@ -12,6 +12,8 @@ export type TranslationFile = {
         viewIncidents: string
         viewIncident: string
         submitReport: string
+        retakePhoto: string
+        takePhoto: string
     }>,
     phrases: Partial<{
         addToHomeScreen: string

--- a/packages/pwa/src/locale/pl.ts
+++ b/packages/pwa/src/locale/pl.ts
@@ -14,6 +14,8 @@ export default {
     viewIncidents: "Zobacz Zdarzenia",
     viewIncident: "Zobacz Zdarzenie",
     submitReport: "Zgłos Zdarzenie",
+    takePhoto: "Zrób Zdjęcie",
+    retakePhoto: "Zrób Zdjęcie Ponownie",
   },
   phrases: {
     addToHomeScreen: "Dodaj SaferPlace do ekranu głównego, aby uzyskać łatwiejszy dostęp!",


### PR DESCRIPTION
Adds the component to take a photo, and then uploads it to the backend.

The returned photo is currently omitted as the API doesn't support photo
references yet.

Closes #40 
