### PR TITLE
pwa: Image Upload

### DIFF
--- a/packages/pwa/.env
+++ b/packages/pwa/.env
@@ -1,1 +1,2 @@
 VITE_BACKEND=http://localhost:8001
+VITE_CDN=http://localhost:9000

--- a/packages/pwa/.env.production
+++ b/packages/pwa/.env.production
@@ -1,1 +1,2 @@
 VITE_BACKEND=https://api.safer.place
+VITE_CDN=https://cdn.safer.place

--- a/packages/pwa/src/hooks/client.ts
+++ b/packages/pwa/src/hooks/client.ts
@@ -11,6 +11,10 @@ export function getEndpoint(): string {
     return localStorage.getItem('backend') ?? import.meta.env.VITE_BACKEND
 }
 
+export function getCDNEndpoint(): string {
+    return localStorage.getItem('cdn') ?? import.meta.env.VITE_CDN
+}
+
 /**
  * getClient creates a new client
  * @param service that the client should connect to.

--- a/packages/pwa/src/locale/en.ts
+++ b/packages/pwa/src/locale/en.ts
@@ -4,6 +4,7 @@ export default {
     common: {
         email: "Email",
         backend: "Backend",
+        cdn: "Content Delivery Network",
         description: "Description",
         submittedAtTime: "Submission Time",
         reportStatus: "Report Status",
@@ -11,6 +12,7 @@ export default {
     action: {
         useEmail: "Use Email",
         useBackend: "Use Backend",
+        useCDN: "Use CDN",
         viewIncidents: "View Incidents",
         viewIncident: "View Incident",
         submitReport: "Submit Report",

--- a/packages/pwa/src/locale/index.ts
+++ b/packages/pwa/src/locale/index.ts
@@ -2,6 +2,7 @@ export type TranslationFile = {
     common: Partial<{
         email: string
         backend: string
+        cdn: string
         description: string
         submittedAtTime: string
         reportStatus: string
@@ -9,6 +10,7 @@ export type TranslationFile = {
     action: Partial<{
         useEmail: string
         useBackend: string
+        useCDN: string
         viewIncidents: string
         viewIncident: string
         submitReport: string

--- a/packages/pwa/src/locale/pl.ts
+++ b/packages/pwa/src/locale/pl.ts
@@ -4,6 +4,7 @@ export default {
   common: {
     email: "E-mail",
     backend: "Backend",
+    cdn: "Sieć Dostarczania Zawartości",
     description: "Opis",
     submittedAtTime: "Złożone o godzinie",
     reportStatus: "Status Zdarzenia",
@@ -11,6 +12,7 @@ export default {
   action: {
     useEmail: "Użyj e-mail",
     useBackend: "Użyj Backendu",
+    useCDN: "Użyj CDNa",
     viewIncidents: "Zobacz Zdarzenia",
     viewIncident: "Zobacz Zdarzenie",
     submitReport: "Zgłos Zdarzenie",

--- a/packages/pwa/src/routes/incident/single.tsx
+++ b/packages/pwa/src/routes/incident/single.tsx
@@ -1,9 +1,10 @@
 import { Incident, Resolution } from "@saferplace/api/incident/v1/incident_pb"
-import { Alert, AlertColor, Box, Card, CardContent, Stack, TextField, Typography } from "@mui/material"
+import { Alert, AlertColor, Box, Card, CardContent, CardMedia, Stack, TextField, Typography } from "@mui/material"
 import { useLoaderData } from "react-router-dom"
 import { useTranslation } from "react-i18next"
 
 import { AccessTime, Done, Warning, HighlightOff } from '@mui/icons-material'
+import { getCDNEndpoint } from "../../hooks/client"
 
 export type Props = {
     incident: Incident
@@ -65,6 +66,13 @@ export default function IncidentDetails() {
                 </Alert>
             )}
             <Card>
+                { incident.imageId && (
+                    <CardMedia
+                        component='img'
+                        src={`${getCDNEndpoint()}/images/${incident.imageId}`}
+                        width='100%'
+                    />
+                )}
                 <CardContent>
                     <Stack spacing={2}>
                         <Typography variant='h4'>{t('common:description')}</Typography>

--- a/packages/pwa/src/routes/login.tsx
+++ b/packages/pwa/src/routes/login.tsx
@@ -6,6 +6,7 @@ import { useTranslation } from 'react-i18next'
 export default function Login() {
     const [email, setEmail] =  React.useState<string>(localStorage.getItem('email') ?? '')
     const [backend, setBackend] = React.useState<string>(localStorage.getItem('backend') ?? import.meta.env.VITE_BACKEND)
+    const [cdn, setCDN] = React.useState<string>(localStorage.getItem('cdn') ?? import.meta.env.VITE_CDN)
     const navigate = useNavigate()
     const { t } = useTranslation()
 
@@ -29,6 +30,10 @@ export default function Login() {
 
     const saveBackend = () => {
         localStorage.setItem('backend', backend)
+    }
+
+    const saveCDN = () => {
+        localStorage.setItem('cdn', cdn)
     }
 
     return (
@@ -59,25 +64,44 @@ export default function Login() {
                             <Typography>{t('phrases:addToHomeScreen')}</Typography>
                         </Stack>
                     </Paper>
-                    <Stack direction={{ xs: 'column', sm: 'row' }}>
-                        <TextField
-                            label={t('common:backend')}
-                            variant='outlined'
-                            fullWidth
-                            type='url'
-                            value={backend}
-                            onChange={(e: React.ChangeEvent<HTMLInputElement>) => {
-                                setBackend(e.target.value)
-                            }}
-                        />
-                        <Button
-                            variant='contained'
-                            fullWidth
-                            onClick={saveBackend}
-                        >
-                            {t('action:useBackend')}
-                        </Button>
+                    <Paper sx={{ padding: 4 }}>
+                        <Stack spacing={2} direction='column'>
+                            <TextField
+                                label={t('common:backend')}
+                                variant='outlined'
+                                fullWidth
+                                type='url'
+                                value={backend}
+                                onChange={(e: React.ChangeEvent<HTMLInputElement>) => {
+                                    setBackend(e.target.value)
+                                }}
+                            />
+                            <Button
+                                variant='contained'
+                                fullWidth
+                                onClick={saveBackend}
+                            >
+                                {t('action:useBackend')}
+                            </Button>
+                            <TextField
+                                label={t('common:cdn')}
+                                variant='outlined'
+                                fullWidth
+                                type='url'
+                                value={cdn}
+                                onChange={(e: React.ChangeEvent<HTMLInputElement>) => {
+                                    setCDN(e.target.value)
+                                }}
+                            />
+                            <Button
+                                variant='contained'
+                                fullWidth
+                                onClick={saveCDN}
+                            >
+                                {t('action:useCDN')}
+                            </Button>
                         </Stack>
+                    </Paper>
                 </Stack>
             </Container>
         </Box>

--- a/packages/pwa/src/routes/report.tsx
+++ b/packages/pwa/src/routes/report.tsx
@@ -39,6 +39,7 @@ export default function Report() {
         setError(null)
 
         let imageID = ''
+        // Only try to upload the image if it has been specified.
         if (image) {
             imageID = await uploadImage()
                 .catch(err => setError(err))
@@ -54,6 +55,7 @@ export default function Report() {
             incident: {
                 description,
                 coordinates,
+                imageId: imageID,
             }
         })
             .then(resp => {

--- a/packages/pwa/src/vite-env.d.ts
+++ b/packages/pwa/src/vite-env.d.ts
@@ -2,6 +2,7 @@
 
 interface ImportMetaEnv {
     readonly VITE_BACKEND: string
+    readonly VITE_CDN: string
 }
 
 interface ImportMeta {


### PR DESCRIPTION
This finishes the last step of adding the uploaded image ID to the
incident request when sending the report.

Since we are relying on the CDN layer now, we also needed to include the
ability to switch the CDN backend.

Closes #41 