### PR TITLE
Pass interceptors to each service

### DIFF
--- a/internal/cmd/saferplace/components.go
+++ b/internal/cmd/saferplace/components.go
@@ -5,12 +5,12 @@ import (
 	"fmt"
 	"slices"
 
-	"github.com/saferplace/webserver-go"
 	"go.uber.org/zap"
 	"golang.org/x/exp/maps"
 	"golang.org/x/sync/errgroup"
 	"safer.place/internal/config"
 	"safer.place/internal/review"
+	"safer.place/internal/service"
 
 	// Registered services
 	"safer.place/internal/service/imageupload"
@@ -112,10 +112,10 @@ func createHeadlessComponents(ctx context.Context, cfg *config.Config, wantedCom
 	return nil
 }
 
-type registerComponentFn func(context.Context, *config.Config, *dependencies) (Service, error)
+type registerComponentFn func(context.Context, *config.Config, *dependencies) (service.Service, error)
 
-func createServices(ctx context.Context, cfg *config.Config, wantedComponents []Component, deps *dependencies, m ComponentRegisterMap) ([]Service, error) {
-	services := make([]webserver.Service, 0, len(wantedComponents))
+func createServices(ctx context.Context, cfg *config.Config, wantedComponents []Component, deps *dependencies, m ComponentRegisterMap) ([]service.Service, error) {
+	services := make([]service.Service, 0, len(wantedComponents))
 	for component, fn := range m {
 		if slices.Contains(wantedComponents, component) {
 			service, err := fn(ctx, cfg, deps)
@@ -143,28 +143,28 @@ func registerConsumer(ctx context.Context, cfg *config.Config, deps *dependencie
 	return nil
 }
 
-func registerReview(_ context.Context, _ *config.Config, deps *dependencies) (Service, error) {
+func registerReview(_ context.Context, _ *config.Config, deps *dependencies) (service.Service, error) {
 	return reviewv1.Register(
 		deps.database,
 		deps.logger.With(zap.String("service", "reviewv1")),
 	), nil
 }
 
-func registerReport(_ context.Context, _ *config.Config, deps *dependencies) (Service, error) {
+func registerReport(_ context.Context, _ *config.Config, deps *dependencies) (service.Service, error) {
 	return reportv1.Register(
 		deps.queue,
 		deps.logger.With(zap.String("service", "reportv1")),
 	), nil
 }
 
-func registerUploader(_ context.Context, _ *config.Config, deps *dependencies) (Service, error) {
+func registerUploader(_ context.Context, _ *config.Config, deps *dependencies) (service.Service, error) {
 	return imageupload.Register(
 		deps.logger.With(zap.String("service", "imageupload")),
 		deps.storage,
 	), nil
 }
 
-func registerViewer(_ context.Context, _ *config.Config, deps *dependencies) (Service, error) {
+func registerViewer(_ context.Context, _ *config.Config, deps *dependencies) (service.Service, error) {
 	return viewerv1.Register(
 		deps.database,
 		deps.logger.With(zap.String("service", "viewerv1")),

--- a/internal/service/imageupload/imageupload.go
+++ b/internal/service/imageupload/imageupload.go
@@ -7,7 +7,9 @@ import (
 	"fmt"
 	"net/http"
 
+	"connectrpc.com/connect"
 	"go.uber.org/zap"
+	"safer.place/internal/service"
 	"safer.place/internal/storage"
 )
 
@@ -18,8 +20,9 @@ type Service struct {
 }
 
 // Register registers the image upload service.
-func Register(log *zap.Logger, store storage.Storage) func() (string, http.Handler) {
-	return func() (string, http.Handler) {
+func Register(log *zap.Logger, store storage.Storage) service.Service {
+	// We can ignore the interceptors as this is a non-connect service
+	return func(_ ...connect.Interceptor) (string, http.Handler) {
 		return "/v1/upload", &Service{
 			log:     log,
 			storage: store,

--- a/internal/service/review/v1/review.go
+++ b/internal/service/review/v1/review.go
@@ -11,6 +11,7 @@ import (
 	"connectrpc.com/connect"
 	"go.uber.org/zap"
 	"safer.place/internal/database"
+	"safer.place/internal/service"
 
 	"api.safer.place/incident/v1"
 	pb "api.safer.place/review/v1"
@@ -27,9 +28,8 @@ type Service struct {
 func Register(
 	db database.Database,
 	log *zap.Logger,
-	interceptors ...connect.Interceptor,
-) func() (string, http.Handler) {
-	return func() (string, http.Handler) {
+) service.Service {
+	return func(interceptors ...connect.Interceptor) (string, http.Handler) {
 		return connectpb.NewReviewServiceHandler(&Service{
 			db:  db,
 			log: log,

--- a/internal/service/service.go
+++ b/internal/service/service.go
@@ -1,0 +1,10 @@
+package service
+
+import (
+	"net/http"
+
+	"connectrpc.com/connect"
+)
+
+// Service is webserver registered function to create a new service, aliased for convenience
+type Service func(...connect.Interceptor) (string, http.Handler)

--- a/internal/service/viewer/v1/viewer.go
+++ b/internal/service/viewer/v1/viewer.go
@@ -14,6 +14,7 @@ import (
 	"connectrpc.com/connect"
 	"go.uber.org/zap"
 	"safer.place/internal/database"
+	"safer.place/internal/service"
 )
 
 const (
@@ -32,12 +33,15 @@ type Service struct {
 func Register(
 	db database.Database,
 	log *zap.Logger,
-) func() (string, http.Handler) {
-	return func() (string, http.Handler) {
-		return viewerconnect.NewViewerServiceHandler(&Service{
-			db:  db,
-			log: log,
-		})
+) service.Service {
+	return func(interceptors ...connect.Interceptor) (string, http.Handler) {
+		return viewerconnect.NewViewerServiceHandler(
+			&Service{
+				db:  db,
+				log: log,
+			},
+			connect.WithInterceptors(interceptors...),
+		)
 	}
 }
 


### PR DESCRIPTION
This creates a new service type which is internal to saferplace, which
takes in the interceptors so that we can add it to every request easily
rather than provide it as an additional argument to each component.

Closes #170 
