### PR TITLE
Image Upload Tracing

### DIFF
--- a/internal/cmd/saferplace/components.go
+++ b/internal/cmd/saferplace/components.go
@@ -159,8 +159,9 @@ func registerReport(_ context.Context, _ *config.Config, deps *dependencies) (se
 
 func registerUploader(_ context.Context, _ *config.Config, deps *dependencies) (service.Service, error) {
 	return imageupload.Register(
-		deps.logger.With(zap.String("service", "imageupload")),
-		deps.storage,
+		imageupload.Logger(deps.logger.With(zap.String("service", "imageupload"))),
+		imageupload.Tracer(deps.tracing.Tracer("imageupload")),
+		imageupload.Storage(deps.storage),
 	), nil
 }
 

--- a/internal/service/imageupload/imageupload.go
+++ b/internal/service/imageupload/imageupload.go
@@ -4,10 +4,13 @@
 package imageupload
 
 import (
+	"errors"
 	"fmt"
 	"net/http"
 
 	"connectrpc.com/connect"
+	"go.opentelemetry.io/otel/codes"
+	"go.opentelemetry.io/otel/trace"
 	"go.uber.org/zap"
 	"safer.place/internal/service"
 	"safer.place/internal/storage"
@@ -15,44 +18,79 @@ import (
 
 // Service is the image upload service
 type Service struct {
+	tracer  trace.Tracer
 	storage storage.Storage
 	log     *zap.Logger
 }
 
 // Register registers the image upload service.
-func Register(log *zap.Logger, store storage.Storage) service.Service {
+func Register(opts ...Option) service.Service {
+	s := &Service{}
+
+	for _, opt := range opts {
+		opt(s)
+	}
+
+	if err := validate(s); err != nil {
+		panic(err)
+	}
+
 	// We can ignore the interceptors as this is a non-connect service
 	return func(_ ...connect.Interceptor) (string, http.Handler) {
-		return "/v1/upload", &Service{
-			log:     log,
-			storage: store,
-		}
+		return "/v1/upload", s
 	}
 }
 
 // ServeHTTP is the handler accepting the image upload.
 func (s *Service) ServeHTTP(w http.ResponseWriter, r *http.Request) {
+	ctx, span := s.tracer.Start(r.Context(), "upload")
+	defer span.End()
 	if err := r.ParseForm(); err != nil {
 		s.log.Error("unable to parse form data", zap.Error(err))
+		span.RecordError(err)
+		span.SetStatus(codes.Error, err.Error())
 		http.Error(w, "unable to parse form", http.StatusBadRequest)
 		return
 	}
 	file, header, err := r.FormFile("image")
 	if err != nil {
 		s.log.Error("unable to get image from user", zap.Error(err))
+		span.RecordError(err)
+		span.SetStatus(codes.Error, err.Error())
 		http.Error(w, "image upload failed", http.StatusBadRequest)
 		return
 	}
 	defer file.Close()
 
 	reference, err := s.storage.Upload(
-		r.Context(), file, header.Size, header.Header.Get("Content-Type"))
+		ctx, file, header.Size, header.Header.Get("Content-Type"))
 	if err != nil {
 		s.log.Error("image upload failed", zap.Error(err))
+		span.RecordError(err)
+		span.SetStatus(codes.Error, err.Error())
 		http.Error(w, "image upload failed", http.StatusInternalServerError)
 		return
 	}
 
 	w.WriteHeader(http.StatusOK)
 	fmt.Fprint(w, reference)
+}
+
+var (
+	errMissingLogger  = errors.New("missing logger")
+	errMissingTrace   = errors.New("missing tracer")
+	errMissingStorage = errors.New("missing storage")
+)
+
+func validate(s *Service) error {
+	if s.log == nil {
+		return errMissingLogger
+	}
+	if s.tracer == nil {
+		return errMissingTrace
+	}
+	if s.storage == nil {
+		return errMissingStorage
+	}
+	return nil
 }

--- a/internal/service/imageupload/option.go
+++ b/internal/service/imageupload/option.go
@@ -1,0 +1,31 @@
+package imageupload
+
+import (
+	"go.opentelemetry.io/otel/trace"
+	"go.uber.org/zap"
+	"safer.place/internal/storage"
+)
+
+// Option to provide configuration to the service.
+type Option func(*Service)
+
+// Logger provides the logger
+func Logger(log *zap.Logger) Option {
+	return func(s *Service) {
+		s.log = log
+	}
+}
+
+// Trace provides the tracing
+func Tracer(tp trace.Tracer) Option {
+	return func(s *Service) {
+		s.tracer = tp
+	}
+}
+
+// Storage provides the storage
+func Storage(store storage.Storage) Option {
+	return func(s *Service) {
+		s.storage = store
+	}
+}

--- a/internal/storage/minio/option.go
+++ b/internal/storage/minio/option.go
@@ -1,0 +1,15 @@
+package minio
+
+import (
+	"go.opentelemetry.io/otel/trace"
+)
+
+// Option extends the functionality of the storage
+type Option func(*Storage)
+
+// Tracer provides the tracing
+func Tracer(t trace.Tracer) Option {
+	return func(s *Storage) {
+		s.tracer = t
+	}
+}


### PR DESCRIPTION
Because the upload service is not based on ConnectRPC, it didn't get
tracing automatically applied. The change adds tracing to the HTTP
endpoint as well as its dependency - storage.

It uses the Options pattern to provide the configuration.

Part of #54 
