### PR TITLE
Remove cSpell Extension

### DIFF
--- a/.vscode/extensions.json
+++ b/.vscode/extensions.json
@@ -1,9 +1,7 @@
 {
     "recommendations": [
-        "streetsidesoftware.code-spell-checker-british-english",
         "mikestead.dotenv",
         "golang.go",
-        "streetsidesoftware.code-spell-checker",
         "humao.rest-client",
         "davidanson.vscode-markdownlint"
     ]

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,13 +1,4 @@
 {
-    "cSpell.language": "en-GB",
-    "cSpell.words": [
-        "direnv",
-        "envrc",
-        "Gardaí",
-        "otel",
-        "saferplace",
-        "workdir"
-    ],
     "files.insertFinalNewline": true,
     "editor.rulers": [100],
     "[markdown]": {
@@ -20,9 +11,6 @@
             "comments": "off",
             "strings": "off",
             "other": "off"
-        },
-        "cSpell.fixSpellingWithRenameProvider": true,
-        "cSpell.advanced.feature.useReferenceProviderWithRename": true,
-        "cSpell.advanced.feature.useReferenceProviderRemove": "/^#+\\s/"
+        }
     }
 }


### PR DESCRIPTION
While useful, it was throwing false positives, making it hard to
understand is it a valid linter problem from another tool, or just a
spelling mistake.
